### PR TITLE
Taxoman Integration to support dynamic facet retrieval

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -3,6 +3,9 @@ from datetime import datetime
 
 from django.conf import settings
 
+if settings.FEATURES.get('ENABLE_TAXOMAN', False):
+    from taxoman_api.models import Facet
+
 from .filter_generator import SearchFilterGenerator
 from .search_engine_base import SearchEngine
 from .result_processor import SearchResultProcessor
@@ -14,7 +17,11 @@ DEFAULT_FILTER_FIELDS = ["org", "modes", "language"]
 
 def course_discovery_filter_fields():
     """ look up the desired list of course discovery filter fields """
-    return getattr(settings, "COURSE_DISCOVERY_FILTERS", DEFAULT_FILTER_FIELDS)
+    filter_fields = getattr(settings, "COURSE_DISCOVERY_FILTERS", DEFAULT_FILTER_FIELDS)
+    if settings.FEATURES.get('ENABLE_TAXOMAN', False):
+        # Does not check for duplicates
+        filter_fields += list(Facet.objects.all().values_list('slug', flat=True))
+    return filter_fields
 
 
 def course_discovery_facets():

--- a/search/views.py
+++ b/search/views.py
@@ -226,6 +226,16 @@ def course_discovery(request):
             err
         )
 
+    if settings.FEATURES.get('ENABLE_TAXOMAN', False):
+        from taxoman_api.api import get_facet_slugs_display_order, get_facet_values_display_order
+        slugs_display_order = get_facet_slugs_display_order()
+        for slug, display_order in slugs_display_order.iteritems():
+            if results['facets'].has_key(slug):
+                results['facets'][slug]['display_order'] = display_order
+                # collect facet value display order
+                fv_display_orders = get_facet_values_display_order(slug)
+                results['facets'][slug]['facet_values'] = fv_display_orders
+
     return HttpResponse(
         json.dumps(results, cls=DjangoJSONEncoder),
         content_type='application/json',

--- a/search/views.py
+++ b/search/views.py
@@ -227,10 +227,13 @@ def course_discovery(request):
         )
 
     if settings.FEATURES.get('ENABLE_TAXOMAN', False):
-        from taxoman_api.api import get_facet_slugs_display_order, get_facet_values_display_order
+        from taxoman_api.api import (
+            get_facet_slugs_display_order,
+            get_facet_values_display_order,
+        )
         slugs_display_order = get_facet_slugs_display_order()
         for slug, display_order in slugs_display_order.iteritems():
-            if results['facets'].has_key(slug):
+            if results.has_key('facets') and results['facets'].has_key(slug):
                 results['facets'][slug]['display_order'] = display_order
                 # collect facet value display order
                 fv_display_orders = get_facet_values_display_order(slug)


### PR DESCRIPTION
This PR has been hanging around, so I updated it with the latest changes for enabling arbitrary sorting of facets and facet values. Basically this PR does a couple of things

1. In `search/api.py` taxoman facets are collected in the filter fields if Taxoman is enabled in the settings

2. arbitrary display order values are inserted into the `course_discovery` response. I tacked on a `facet_values` dict into each slug's response set instead of rewriting how 'term' (this is the facet value) works in the backbone.js front end code