### PR TITLE
Hack filter discovery results

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -77,6 +77,51 @@ def perform_search(
     return results
 
 
+def _hack_filter_discovery_results(results):
+    """
+    Filter CourseDiscovery search results.
+
+    This is a hack function that should be refactored into the LMS.
+    See RED-637.
+    """
+    from courseware.access import has_access
+    from crum import get_current_request
+    from opaque_keys.edx.keys import CourseKey
+    from xmodule.modulestore.django import modulestore
+    import six
+
+    ms = modulestore()
+    user = get_current_request().user
+
+    for result in results["results"]:
+        if not has_access(
+            user,
+            'see_in_catalog',
+            ms.get_course(CourseKey.from_string(result['data']['id']), depth=0)
+        ):
+            result["data"] = None
+
+    # Count and remove the results that has no access
+    access_denied_count = len([r for r in results["results"] if r["data"] is None])
+    results["access_denied_count"] = access_denied_count
+    results["results"] = [r for r in results["results"] if r["data"] is not None]
+
+    # Hack: Naively reduce the facet numbers by the access denied results
+    # This is not the smartest hack, and customers could report issues
+    # The solution is most likely to just remove the facet numbers
+    results["total"] = max(0, results["total"] - access_denied_count)
+    for name, facet in six.iteritems(results["facets"]):
+        results["total"] = max(0, results["total"] - access_denied_count)
+        facet["other"] = max(0, facet["other"] - access_denied_count)
+        facet["terms"] = {
+            term: max(0, count - access_denied_count)
+            for term, count in six.iteritems(facet["terms"])
+            # Remove the facet terms that has no results
+            if max(0, count - access_denied_count)
+        }
+    return results
+
+
 def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary=None):
     """
     Course Discovery activities against the search engine index of course details
@@ -107,4 +152,4 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         sort=getattr(settings, 'SEARCH_DISCOVERY_SORT_FIELDS', ''),
     )
 
-    return results
+    return _hack_filter_discovery_results(results)


### PR DESCRIPTION
Ensure that search results are checked by `has_access` to allow for Access Control Backends to ensure we have a foundation for Course Access Groups.

This is meant to be a temporary hack that we'll stop using later on. The full reasoning behind this is available in this [decision document](https://appsembler.atlassian.net/wiki/spaces/RT/pages/65568897/Draft+Decision+How+should+we+combine+Course+Access+Groups+and+edX+Search).