### PR TITLE
RED-1488 - Hack: filter discovery results for access group support on Juniper.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,24 @@ python:
 - 3.5
 
 envs:
-- TOXENV=django111
-- TOXENV=django20
-- TOXENV=django21
-- TOXENV=django22
+# - TOXENV=django111
+- TOXENV=py35-django20
+# - TOXENV=django21
+# - TOXENV=django22
 - TOXENV=quality
 
-matrix:
-  include:
-    - python: 2.7
-      env: TOXENV=quality
-    - python: 2.7
-      env: TOXENV=django111
-    - python: 3.6
-      env: TOXENV=django22
-    - python: 3.7
-      env: TOXENV=django22
-    - python: 3.8
-      env: TOXENV=django22
+#matrix:
+#  include:
+#    - python: 2.7
+#      env: TOXENV=quality
+#    - python: 2.7
+#      env: TOXENV=django111
+#    - python: 3.6
+#      env: TOXENV=django22
+#    - python: 3.7
+#      env: TOXENV=django22
+#    - python: 3.8
+#      env: TOXENV=django22
 
 addons:
   apt:
@@ -47,13 +47,13 @@ script: tox
 
 after_success: codecov
 
-deploy:
-  provider: pypi
-  user: edx
-  password:
-    secure: FIBjU6/5WPzUHqNWO9OqPdt3YipxSs7WPTnKMTJwlEvixXCIRkmAXd1CBd7kSYa0GvCfLSei7xLKsgUKaCe+OBsnw/ZDBllZv5EvLJwdKn/EKrPxhxeQ6/SNtqafWQ3mLL1+gosh0RHQdy0HlwwS+m/Qsf+51ohIJVpt+5jwxFA=
-  distributions: sdist bdist_wheel
-  on:
-    tags: true
-    python: 3.5
-    condition: '$TOXENV = django111'
+#deploy:
+#  provider: pypi
+#  user: edx
+#  password:
+#    secure: FIBjU6/5WPzUHqNWO9OqPdt3YipxSs7WPTnKMTJwlEvixXCIRkmAXd1CBd7kSYa0GvCfLSei7xLKsgUKaCe+OBsnw/ZDBllZv5EvLJwdKn/EKrPxhxeQ6/SNtqafWQ3mLL1+gosh0RHQdy0HlwwS+m/Qsf+51ohIJVpt+5jwxFA=
+#  distributions: sdist bdist_wheel
+#  on:
+#    tags: true
+#    python: 3.5
+#    condition: '$TOXENV = django111'

--- a/search/api.py
+++ b/search/api.py
@@ -96,7 +96,7 @@ def _hack_filter_discovery_results(results):
         if not has_access(
             user,
             'see_in_catalog',
-            ms.get_course(CourseKey.from_string(result['data']['id']), depth=0)
+            CourseKey.from_string(result['data']['id'])
         ):
             result["data"] = None
 

--- a/search/api.py
+++ b/search/api.py
@@ -77,6 +77,51 @@ def perform_search(
     return results
 
 
+def _hack_filter_discovery_results(results):
+    """
+    Filter CourseDiscovery search results.
+
+    This is a hack function that should be refactored into the LMS.
+    See RED-637.
+    """
+    from courseware.access import has_access
+    from crum import get_current_request
+    from opaque_keys.edx.keys import CourseKey
+    from xmodule.modulestore.django import modulestore
+    import six
+
+    ms = modulestore()
+    user = get_current_request().user
+
+    for result in results["results"]:
+        if not has_access(
+            user,
+            'see_in_catalog',
+            ms.get_course(CourseKey.from_string(result['data']['id']), depth=0)
+        ):
+            result["data"] = None
+
+    # Count and remove the results that has no access
+    access_denied_count = len([r for r in results["results"] if r["data"] is None])
+    results["access_denied_count"] = access_denied_count
+    results["results"] = [r for r in results["results"] if r["data"] is not None]
+
+    # Hack: Naively reduce the facet numbers by the access denied results
+    # This is not the smartest hack, and customers could report issues
+    # The solution is most likely to just remove the facet numbers
+    results["total"] = max(0, results["total"] - access_denied_count)
+    for name, facet in six.iteritems(results["facets"]):
+        results["total"] = max(0, results["total"] - access_denied_count)
+        facet["other"] = max(0, facet.get("other", 0) - access_denied_count)
+        facet["terms"] = {
+            term: max(0, count - access_denied_count)
+            for term, count in six.iteritems(facet["terms"])
+            # Remove the facet terms that has no results
+            if max(0, count - access_denied_count)
+        }
+    return results
+
+
 def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary=None):
     """
     Course Discovery activities against the search engine index of course details
@@ -109,4 +154,4 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         facet_terms=course_discovery_facets(),
     )
 
-    return results
+    return _hack_filter_discovery_results(results)

--- a/search/api.py
+++ b/search/api.py
@@ -84,11 +84,10 @@ def _hack_filter_discovery_results(results):
     This is a hack function that should be refactored into the LMS.
     See RED-637.
     """
-    from courseware.access import has_access
+    from lms.djangoapps.courseware.access import has_access
     from crum import get_current_request
     from opaque_keys.edx.keys import CourseKey
     from xmodule.modulestore.django import modulestore
-    import six
 
     ms = modulestore()
     user = get_current_request().user
@@ -110,12 +109,12 @@ def _hack_filter_discovery_results(results):
     # This is not the smartest hack, and customers could report issues
     # The solution is most likely to just remove the facet numbers
     results["total"] = max(0, results["total"] - access_denied_count)
-    for name, facet in six.iteritems(results["facets"]):
+    for name, facet in list(results["facets"].items()):
         results["total"] = max(0, results["total"] - access_denied_count)
         facet["other"] = max(0, facet.get("other", 0) - access_denied_count)
         facet["terms"] = {
             term: max(0, count - access_denied_count)
-            for term, count in six.iteritems(facet["terms"])
+            for term, count in list(facet["terms"].items())
             # Remove the facet terms that has no results
             if max(0, count - access_denied_count)
         }

--- a/search/api.py
+++ b/search/api.py
@@ -84,20 +84,15 @@ def _hack_filter_discovery_results(results):
     This is a hack function that should be refactored into the LMS.
     See RED-637.
     """
-    from lms.djangoapps.courseware.access import has_access
-    from crum import get_current_request
-    from opaque_keys.edx.keys import CourseKey
-    from xmodule.modulestore.django import modulestore
+    from lms.djangoapps.courseware.access import has_access  # pylint: disable=import-error
+    from crum import get_current_request  # pylint: disable=import-error
+    from opaque_keys.edx.keys import CourseKey  # pylint: disable=import-error
 
-    ms = modulestore()
     user = get_current_request().user
 
     for result in results["results"]:
-        if not has_access(
-            user,
-            'see_in_catalog',
-            CourseKey.from_string(result['data']['id'])
-        ):
+        course_key = CourseKey.from_string(result['data']['id'])
+        if not has_access(user, 'see_in_catalog', course_key):
             result["data"] = None
 
     # Count and remove the results that has no access
@@ -109,7 +104,7 @@ def _hack_filter_discovery_results(results):
     # This is not the smartest hack, and customers could report issues
     # The solution is most likely to just remove the facet numbers
     results["total"] = max(0, results["total"] - access_denied_count)
-    for name, facet in list(results["facets"].items()):
+    for _name, facet in list(results["facets"].items()):
         results["total"] = max(0, results["total"] - access_denied_count)
         facet["other"] = max(0, facet.get("other", 0) - access_denied_count)
         facet["terms"] = {


### PR DESCRIPTION
RED-1488: Add course access group support that we had for Hawthorn in #12 and #15.

This is hack that we're carrying over. Addressing this tech-debt is out of the scope of Juniper and I'm going to write about it in this document:
 * [TechDebt and upstream contribution for Course Access Groups](https://appsembler.atlassian.net/wiki/spaces/JUP/pages/938672496/Draft+TechDebt+and+upstream+contribution+for+Course+Access+Groups)

### TODO

 - [x] Review the `_hack_filter_discovery_results` for:
   * [x] Python 3
   * [x] Django 2.2
   * [x] Juniper import paths
 - [x] Run tests



### New `main` branch
The `master` branch was working for Hawthorn, but it had a history problem that prevents it from being upgraded cleanly. `main` is a new branch for Juniper that's addressing the issue. I've wrote about the issue in the [CAG upgrade doc](https://appsembler.atlassian.net/wiki/spaces/JUP/pages/925073761/Course+Access+Group+for+Juniper+#edX-Search-support-for-has_access).

This PR fixes the issue by starting off a clean branch and cherry-picking the commits below from Hawthorn:

 - 6fac426 2020-01-07 | ValueError: Fix missing `other` key in search
 - 2dced47 2019-12-18 | (WIP) Hack filter discovery results
