### PR TITLE
RED-1488: Fix tests by disabling our hack; bump version

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -84,6 +84,9 @@ def _hack_filter_discovery_results(results):
     This is a hack function that should be refactored into the LMS.
     See RED-637.
     """
+    if not getattr(settings, 'TAHOE_ENABLE_HAS_ACCESS_FILTER', True):
+        return results
+
     from lms.djangoapps.courseware.access import has_access  # pylint: disable=import-error
     from crum import get_current_request  # pylint: disable=import-error
     from opaque_keys.edx.keys import CourseKey  # pylint: disable=import-error

--- a/settings.py
+++ b/settings.py
@@ -100,6 +100,8 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 
+TAHOE_ENABLE_HAS_ACCESS_FILTER = False  # Turn off the hack during tests
+
 ############################## EVENT TRACKING #################################
 
 TRACK_MAX_EVENT = 50000

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def is_requirement(line):
 
 setup(
     name='edx-search',
-    version='1.3.4',
+    version='1.3.4-appsembler2',
     description='Search and index routines for index access',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
 - RED-1488: I forgot to push a fix to GitHub. Tests runs, but only with the hack disabled bcuz of dependency on LMS. 
 - I bumped the version so we can pin it in appsembler/edx-platform#720

#### Why not create `mocks`?
I don't want to create mocks for this package because we're supposed to fix this tech-debt in RED-637.
