### PR TITLE
RED-1595: Fix `ValueError` for `see_in_catalog` action in `has_access`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 envs:
 # - TOXENV=django111
-- TOXENV=py35-django20
+- TOXENV=py35-django22
 # - TOXENV=django21
 # - TOXENV=django22
 - TOXENV=quality

--- a/openedx_tahoe_mocks/__init__.py
+++ b/openedx_tahoe_mocks/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mocks so the tests can run without having to install Open edX as a dependency.
+"""

--- a/openedx_tahoe_mocks/crum.py
+++ b/openedx_tahoe_mocks/crum.py
@@ -1,0 +1,15 @@
+"""
+Mock django-crum.
+"""
+
+from unittest.mock import Mock
+from django.contrib.auth.models import User
+
+
+def get_current_request():
+    """
+    Mock the crum.get_current_request function.
+    """
+    request = Mock()
+    request.user = User()
+    return request

--- a/openedx_tahoe_mocks/lms/__init__.py
+++ b/openedx_tahoe_mocks/lms/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mocks for the lms module so tests can run.
+"""

--- a/openedx_tahoe_mocks/lms/djangoapps/__init__.py
+++ b/openedx_tahoe_mocks/lms/djangoapps/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mocks for the lms.djangoapps module so tests can run.
+"""

--- a/openedx_tahoe_mocks/lms/djangoapps/courseware/__init__.py
+++ b/openedx_tahoe_mocks/lms/djangoapps/courseware/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mocks for the lms.djangoapps.courseware module so tests can run.
+"""

--- a/openedx_tahoe_mocks/lms/djangoapps/courseware/access.py
+++ b/openedx_tahoe_mocks/lms/djangoapps/courseware/access.py
@@ -1,0 +1,16 @@
+"""
+Mocks for the lms.djangoapps.courseware.access module so tests can run.
+"""
+
+from django.contrib.auth.models import User, AnonymousUser
+from opaque_keys.edx.keys import CourseKey
+
+
+def has_access(user, action, obj):
+    """
+    Mock the LMS has_access function.
+    """
+    assert isinstance(user, (User, AnonymousUser)), 'Should have a user passed to it.'
+    assert action == 'see_in_catalog', 'Only one action is needed for edx-search'
+    assert isinstance(obj, CourseKey), 'expecting a course key'
+    return True  # avoid breaking `edx-search` tests

--- a/openedx_tahoe_mocks/lms/djangoapps/courseware/access.py
+++ b/openedx_tahoe_mocks/lms/djangoapps/courseware/access.py
@@ -12,5 +12,5 @@ def has_access(user, action, obj):
     """
     assert isinstance(user, (User, AnonymousUser)), 'Should have a user passed to it.'
     assert action == 'see_in_catalog', 'Only one action is needed for edx-search'
-    assert isinstance(obj, CourseKey), 'expecting a course key'
+    assert isinstance(obj.id, CourseKey), 'expecting a course object to match LMS see_in_catalog check'
     return True  # avoid breaking `edx-search` tests

--- a/openedx_tahoe_mocks/xmodule/__init__.py
+++ b/openedx_tahoe_mocks/xmodule/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mocks for the `xmodule` module so tests can run.
+"""

--- a/openedx_tahoe_mocks/xmodule/modulestore/__init__.py
+++ b/openedx_tahoe_mocks/xmodule/modulestore/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mocks for xmodule.modulestore so tests can run.
+"""

--- a/openedx_tahoe_mocks/xmodule/modulestore/django.py
+++ b/openedx_tahoe_mocks/xmodule/modulestore/django.py
@@ -3,6 +3,7 @@ Mocks for xmodule.modulestore.django tests can run.
 """
 
 from unittest.mock import Mock
+from opaque_keys.edx.keys import CourseKey
 
 
 def get_course(course_key, depth=0):
@@ -10,7 +11,7 @@ def get_course(course_key, depth=0):
     Mock get_course function.
     """
     assert depth == 0, 'Avoid loading entire course.'
-    assert str(course_key).startswith('course-v1:')
+    assert isinstance(course_key, CourseKey), 'this function expects a valid course key'
     course = Mock()
     course.id = course_key
     return course

--- a/openedx_tahoe_mocks/xmodule/modulestore/django.py
+++ b/openedx_tahoe_mocks/xmodule/modulestore/django.py
@@ -1,0 +1,25 @@
+"""
+Mocks for xmodule.modulestore.django tests can run.
+"""
+
+from unittest.mock import Mock
+
+
+def get_course(course_key, depth=0):
+    """
+    Mock get_course function.
+    """
+    assert depth == 0, 'Avoid loading entire course.'
+    assert str(course_key).startswith('course-v1:')
+    course = Mock()
+    course.id = course_key
+    return course
+
+
+def modulestore():
+    """
+    Mock modulestore factory.
+    """
+    store = Mock()
+    store.get_course = get_course
+    return store

--- a/search/api.py
+++ b/search/api.py
@@ -8,6 +8,7 @@ from .filter_generator import SearchFilterGenerator
 from .search_engine_base import SearchEngine
 from .result_processor import SearchResultProcessor
 from .utils import DateRange
+from .tahoe_hacks import has_access_for_results
 
 # Default filters that we support, override using COURSE_DISCOVERY_FILTERS setting if desired
 DEFAULT_FILTER_FIELDS = ["org", "modes", "language"]
@@ -77,48 +78,6 @@ def perform_search(
     return results
 
 
-def _hack_filter_discovery_results(results):
-    """
-    Filter CourseDiscovery search results.
-
-    This is a hack function that should be refactored into the LMS.
-    See RED-637.
-    """
-    if not getattr(settings, 'TAHOE_ENABLE_HAS_ACCESS_FILTER', True):
-        return results
-
-    from lms.djangoapps.courseware.access import has_access  # pylint: disable=import-error
-    from crum import get_current_request  # pylint: disable=import-error
-    from opaque_keys.edx.keys import CourseKey  # pylint: disable=import-error
-
-    user = get_current_request().user
-
-    for result in results["results"]:
-        course_key = CourseKey.from_string(result['data']['id'])
-        if not has_access(user, 'see_in_catalog', course_key):
-            result["data"] = None
-
-    # Count and remove the results that has no access
-    access_denied_count = len([r for r in results["results"] if r["data"] is None])
-    results["access_denied_count"] = access_denied_count
-    results["results"] = [r for r in results["results"] if r["data"] is not None]
-
-    # Hack: Naively reduce the facet numbers by the access denied results
-    # This is not the smartest hack, and customers could report issues
-    # The solution is most likely to just remove the facet numbers
-    results["total"] = max(0, results["total"] - access_denied_count)
-    for _name, facet in list(results["facets"].items()):
-        results["total"] = max(0, results["total"] - access_denied_count)
-        facet["other"] = max(0, facet.get("other", 0) - access_denied_count)
-        facet["terms"] = {
-            term: max(0, count - access_denied_count)
-            for term, count in list(facet["terms"].items())
-            # Remove the facet terms that has no results
-            if max(0, count - access_denied_count)
-        }
-    return results
-
-
 def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary=None):
     """
     Course Discovery activities against the search engine index of course details
@@ -151,4 +110,4 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         facet_terms=course_discovery_facets(),
     )
 
-    return _hack_filter_discovery_results(results)
+    return has_access_for_results(results)

--- a/search/tahoe_hacks.py
+++ b/search/tahoe_hacks.py
@@ -2,8 +2,6 @@
 Module for Tahoe hacks for the edx-search repository.
 """
 
-from django.conf import settings
-
 
 def has_access_for_results(results):
     """
@@ -12,9 +10,6 @@ def has_access_for_results(results):
     This is a hack function that should be refactored into the LMS.
     See RED-637.
     """
-    if not getattr(settings, 'TAHOE_ENABLE_HAS_ACCESS_FILTER', True):
-        return results
-
     from lms.djangoapps.courseware.access import has_access
     from crum import get_current_request
     from opaque_keys.edx.keys import CourseKey

--- a/search/tahoe_hacks.py
+++ b/search/tahoe_hacks.py
@@ -15,9 +15,9 @@ def has_access_for_results(results):
     if not getattr(settings, 'TAHOE_ENABLE_HAS_ACCESS_FILTER', True):
         return results
 
-    from lms.djangoapps.courseware.access import has_access  # pylint: disable=import-error
-    from crum import get_current_request  # pylint: disable=import-error
-    from opaque_keys.edx.keys import CourseKey  # pylint: disable=import-error
+    from lms.djangoapps.courseware.access import has_access
+    from crum import get_current_request
+    from opaque_keys.edx.keys import CourseKey
 
     user = get_current_request().user
 

--- a/search/tahoe_hacks.py
+++ b/search/tahoe_hacks.py
@@ -1,0 +1,47 @@
+"""
+Module for Tahoe hacks for the edx-search repository.
+"""
+
+from django.conf import settings
+
+
+def has_access_for_results(results):
+    """
+    Filter CourseDiscovery search results via the edX Platform LMS `has_access` function.
+
+    This is a hack function that should be refactored into the LMS.
+    See RED-637.
+    """
+    if not getattr(settings, 'TAHOE_ENABLE_HAS_ACCESS_FILTER', True):
+        return results
+
+    from lms.djangoapps.courseware.access import has_access  # pylint: disable=import-error
+    from crum import get_current_request  # pylint: disable=import-error
+    from opaque_keys.edx.keys import CourseKey  # pylint: disable=import-error
+
+    user = get_current_request().user
+
+    for result in results["results"]:
+        course_key = CourseKey.from_string(result['data']['id'])
+        if not has_access(user, 'see_in_catalog', course_key):
+            result["data"] = None
+
+    # Count and remove the results that has no access
+    access_denied_count = len([r for r in results["results"] if r["data"] is None])
+    results["access_denied_count"] = access_denied_count
+    results["results"] = [r for r in results["results"] if r["data"] is not None]
+
+    # Hack: Naively reduce the facet numbers by the access denied results
+    # This is not the smartest hack, and customers could report issues
+    # The solution is most likely to just remove the facet numbers
+    results["total"] = max(0, results["total"] - access_denied_count)
+    for _name, facet in list(results["facets"].items()):
+        results["total"] = max(0, results["total"] - access_denied_count)
+        facet["other"] = max(0, facet.get("other", 0) - access_denied_count)
+        facet["terms"] = {
+            term: max(0, count - access_denied_count)
+            for term, count in list(facet["terms"].items())
+            # Remove the facet terms that has no results
+            if max(0, count - access_denied_count)
+        }
+    return results

--- a/search/tahoe_hacks.py
+++ b/search/tahoe_hacks.py
@@ -13,12 +13,15 @@ def has_access_for_results(results):
     from lms.djangoapps.courseware.access import has_access
     from crum import get_current_request
     from opaque_keys.edx.keys import CourseKey
+    from xmodule.modulestore.django import modulestore
 
+    module_store = modulestore()
     user = get_current_request().user
 
     for result in results["results"]:
         course_key = CourseKey.from_string(result['data']['id'])
-        if not has_access(user, 'see_in_catalog', course_key):
+        course = module_store.get_course(course_key, depth=0)
+        if not has_access(user, 'see_in_catalog', course):
             result["data"] = None
 
     # Count and remove the results that has no access

--- a/settings.py
+++ b/settings.py
@@ -100,8 +100,6 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 
-TAHOE_ENABLE_HAS_ACCESS_FILTER = False  # Turn off the hack during tests
-
 ############################## EVENT TRACKING #################################
 
 TRACK_MAX_EVENT = 50000

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def is_requirement(line):
 
 setup(
     name='edx-search',
-    version='1.3.4-appsembler2',
+    version='1.3.4-appsembler3',
     description='Search and index routines for index access',
     author='edX',
     author_email='oscm@edx.org',

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@ envlist = py27-django111,py35-django{111,20,21,22},py{36,37,38}-django22,quality
 [testenv]
 setenv =
     DJANGO_SETTINGS_MODULE = edxsearch.settings
-    # This allows us to reference settings.py
-    PYTHONPATH = {toxinidir}
+    # This allows us to reference settings.py and use Open edX mocks for the Tahoe hack
+    PYTHONPATH = {toxinidir}:{toxinidir}/openedx_tahoe_mocks
 deps =
-    django111: Django>=1.11,<2
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
+;    django111: Django>=1.11,<2  # Disable tests for anything other than Django 22
+;    django20: Django>=2.0,<2.1
+;    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    edx-opaque-keys==2.1.0
     -r {toxinidir}/requirements/testing.txt
 commands =
     python -Wd -m coverage run manage.py test --settings=settings {posargs}
@@ -20,6 +21,7 @@ commands =
 whitelist_externals =
     make
 deps =
+    edx-opaque-keys==2.1.0
     -r{toxinidir}/requirements/quality.txt
 commands =
     make quality


### PR DESCRIPTION
RED-1595.

### Bug details
An LMS test fails due to 3192723 commit which replaced course with just course key.

```
$ cd juniper/edx-platform
$ tox -e pytest lms/djangoapps/course_api/tests/test_views.py::CourseListSearchViewTest::test_list_all_with_search_term
ValueError: Unknown action for object type '<class 'opaque_keys.edx.locator.CourseLocator'>': 'see_in_catalog'
```

### The fix

The actual fix is only 4af3496 `Use course object to fix lms test failure`. The rest of the commits are refactoring and adding mocks.


### Refactoring and mocks
This PR refactors our hack so the code runs. This helps to detect syntax and subtle runtime errors.
I'm not adding extensive tests yet, but this is a good start.
