### PR TITLE
fix: search results count (`total`) is set to zero incorrectly (2nd take)

### DIFF
--- a/search/tahoe_hacks.py
+++ b/search/tahoe_hacks.py
@@ -10,7 +10,7 @@ def has_access_for_results(results):
     This is a hack function that should be refactored into the LMS.
     See RED-637.
     """
-    from lms.djangoapps.courseware.access import has_access
+    from lms.djangoapps.courseware import access
     from crum import get_current_request
     from opaque_keys.edx.keys import CourseKey
     from xmodule.modulestore.django import modulestore
@@ -21,7 +21,7 @@ def has_access_for_results(results):
     for result in results["results"]:
         course_key = CourseKey.from_string(result['data']['id'])
         course = module_store.get_course(course_key, depth=0)
-        if not has_access(user, 'see_in_catalog', course):
+        if not access.has_access(user, 'see_in_catalog', course):
             result["data"] = None
 
     # Count and remove the results that has no access
@@ -34,7 +34,6 @@ def has_access_for_results(results):
     # The solution is most likely to just remove the facet numbers
     results["total"] = max(0, results["total"] - access_denied_count)
     for _name, facet in list(results["facets"].items()):
-        results["total"] = max(0, results["total"] - access_denied_count)
         facet["other"] = max(0, facet.get("other", 0) - access_denied_count)
         facet["terms"] = {
             term: max(0, count - access_denied_count)

--- a/search/tests/test_tahoe_hacks.py
+++ b/search/tests/test_tahoe_hacks.py
@@ -1,0 +1,83 @@
+"""
+Tests for the tahoe_hacks module.
+
+This tech-debt and we should implement a proper edx-search results processor:
+ - Tech debt task: https://appsembler.atlassian.net/browse/RED-637
+ - CourseDiscoveryResultProcessor implementation: https://github.com/appsembler/edx-search/pull/2
+"""
+
+from django.test import TestCase
+from mock import patch, Mock
+
+from search.tahoe_hacks import has_access_for_results
+
+
+class TestHackFilterDiscoveryResults(TestCase):
+
+    @patch('lms.djangoapps.courseware.access.has_access', Mock(return_value=True))
+    def test_all_have_access(self):
+        pre_results = get_mock_course_discovery_search_results()
+        results = has_access_for_results(pre_results)
+        self.assertEqual(results['total'], 4)  # Should not change result count, no course should be denied
+        self.assertEqual(results['access_denied_count'], 0)  # All courses should be allowed
+        self.assertEqual(len(results['results']), 4)  # Result count should match `total`
+
+    @patch('lms.djangoapps.courseware.access.has_access')
+    def test_allow_two_out_of_four(self, mock_has_access):
+        """
+        Ensure `total` is counted correctly when removing
+        """
+
+        pre_results = get_mock_course_discovery_search_results()
+        first_random_two_courses = {r['data']['id'] for r in pre_results['results'][:2]}
+
+        def fake_has_access_replacement(user, action, course):
+            """
+            Grant access to the first two courses just to test access_denied_count/total calculations.
+            """
+            return str(course.id) in first_random_two_courses
+
+        mock_has_access.side_effect = fake_has_access_replacement
+        results = has_access_for_results(pre_results)
+        self.assertEqual(results['access_denied_count'], 2)  # Only two courses should be allowed
+        self.assertEqual(len(results['results']), 2)  # Result count should match `total`
+        self.assertEqual(results['total'], 2)  # Should count the remaining two courses
+
+
+def get_mock_course_discovery_search_results():
+    """
+    Get similar data to edx-search's search/api.py course_discovery_search function.
+    """
+    return {
+        "total": 4,
+        "results": [
+            {
+                "data": {
+                    "id": "course-v1:delta-rook+CEDE+2021",
+                },
+            },
+            {
+                "data": {
+                    "id": "course-v1:delta-rook+Template+2019",
+                },
+            },
+            {
+                "data": {
+                    "id": "course-v1:delta-rook+OE201+2018",
+                },
+            },
+            {
+                "data": {
+                    "id": "course-v1:delta-rook+AVL101+2018",
+                },
+            },
+        ],
+        "facets": {
+            "language": {"total": 12, "other": 0, "terms": {"en": 12}},
+            "org": {"total": 12, "other": 0, "terms": {"delta-rook": 12}},
+            "modes": {"total": 12, "other": 0, "terms": {"honor": 12}},
+        },
+        "max_score": 1,
+        "took": 2,
+        "access_denied_count": 0,
+    }

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def is_requirement(line):
 
 setup(
     name='edx-search',
-    version='1.3.4-appsembler3',
+    version='1.3.4-appsembler5',
     description='Search and index routines for index access',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
Same as #21 but on the Juniper's `main` branch. I made a mistake and fixed the Hawthorn branch 😒

**Jira issue:** RED-2440. 

This bug affects many customers, the problem was that `count - access_denied_count` was done multiple times:

```py
count = 10
access_denied_count = 5
count -= access_denied_count  # count = 5, correct
for f in facets:
  count -= access_denied_count  # incorrect and has been removed
```

 - Fixed the `total` bug 
 - Added tests

Run `tox` locally:

```
$ tox -e py35-django22 search.tests.test_tahoe_hacks
```


### Testing

 - [x] Tried this branch via `pip install https://github.com/appsembler/edx-search/archive/count_fix2.tar.gz` on edX Platform's `main` and it worked by running ✅ `tox -e pytest -- cms/djangoapps/contentstore/tests/test_courseware_index.py::TestCoursewareSearchIndexer`