### PR TITLE
bug fix for deleted courses but still in ElasticSearch

### DIFF
--- a/search/tahoe_hacks.py
+++ b/search/tahoe_hacks.py
@@ -21,7 +21,7 @@ def has_access_for_results(results):
     for result in results["results"]:
         course_key = CourseKey.from_string(result['data']['id'])
         course = module_store.get_course(course_key, depth=0)
-        if not access.has_access(user, 'see_in_catalog', course):
+        if not (course and access.has_access(user, 'see_in_catalog', course)):
             result["data"] = None
 
     # Count and remove the results that has no access

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def is_requirement(line):
 
 setup(
     name='edx-search',
-    version='1.3.4-appsembler5',
+    version='1.3.4-appsembler6',
     description='Search and index routines for index access',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
**Jira issue:** RED-2440.

`modulestore().get_course()` may return `None` despite the course being indexed in ElasticSearch. In this case, the course should be treated as if `has_access()` returned `False` i.e. the course will be filtered from the results.

```
TypeError
/search/course_discovery/
Unknown object type in has_access(): <class 'NoneType'>

...
if not access.has_access(user, 'see_in_catalog', course):
...
```
